### PR TITLE
Correct Subscriber server information

### DIFF
--- a/prc_Repl_Articles.sql
+++ b/prc_Repl_Articles.sql
@@ -16,18 +16,18 @@ BEGIN
 	IF (DB_ID('distribution') IS NOT NULL)
 	BEGIN
 		SELECT s.publisher_id, ss2.data_source, a.publisher_db, p.publication
-		 , s.subscriber_id, ss.data_source as SubscriberServer, s.subscriber_db
+		 , s.subscriber_id, ss.srvname as SubscriberServer, s.subscriber_db
 		 , a.source_owner, a.source_object 
 		 , ISNULL(a.destination_owner, a.source_owner) destination_owner -- if NULL, schema name remains same at subscriber side 
 		 , a.destination_object 
 		FROM distribution.dbo.MSarticles AS a 
 			INNER JOIN distribution.dbo.MSsubscriptions AS s ON a.publication_id = s.publication_id AND a.article_id = s.article_id 
-			INNER JOIN master.sys.servers AS ss ON s.subscriber_id = ss.server_id 
+			INNER JOIN distribution.[dbo].[MSreplservers] AS ss ON s.subscriber_id = ss.srvid 
 			INNER JOIN distribution.dbo.MSpublications AS p ON s.publication_id = p.publication_id 
 			LEFT JOIN master.sys.servers AS ss2 ON p.publisher_id = ss2.server_id 
 		WHERE s.subscriber_db <> 'virtual'
 		ORDER BY ss2.data_source, a.publisher_db, p.publication
-			, ss.data_source, a.source_owner, a.source_object 
+			, ss.srvname, a.source_owner, a.source_object 
 	END
 	ELSE
 	BEGIN


### PR DESCRIPTION
MSSubscriptions subscriber_id does not have a valid relationship with sysservers server_id.  The correct id is hold on the MSreplservers srvid column.